### PR TITLE
Ensure memory units are appended to memory settings

### DIFF
--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -24,3 +24,6 @@ config_properties = config['configurations']['config.properties']
 
 daemon_control_script = '/etc/init.d/presto'
 config_directory = '/etc/presto'
+
+memory_configs = ['query.max-memory-per-node', 'query.max-memory',
+                  'task.max-memory']

--- a/package/scripts/presto_coordinator.py
+++ b/package/scripts/presto_coordinator.py
@@ -43,7 +43,7 @@ class Coordinator(Script):
 
     def configure(self, env):
         from params import node_properties, jvm_config, config_properties, \
-            config_directory
+            config_directory, memory_configs
         key_val_template = '{0}={1}\n'
 
         with open(path.join(config_directory, 'node.properties'), 'w') as f:
@@ -62,6 +62,8 @@ class Coordinator(Script):
                 # the user visible equivalent to node-scheduler.include-coordinator
                 if key == 'pseudo.distributed.enabled':
                     continue
+                if key in memory_configs:
+                    value += 'GB'
                 f.write(key_val_template.format(key, value))
             f.write(key_val_template.format('coordinator', 'true'))
             f.write(key_val_template.format('discovery-server.enabled', 'true'))

--- a/package/scripts/presto_worker.py
+++ b/package/scripts/presto_worker.py
@@ -41,7 +41,7 @@ class Worker(Script):
 
     def configure(self, env):
         from params import node_properties, jvm_config, config_properties, \
-            config_directory
+            config_directory, memory_configs
         key_val_template = '{0}={1}\n'
 
         with open(path.join(config_directory, 'node.properties'), 'w') as f:
@@ -58,6 +58,8 @@ class Worker(Script):
                     continue
                 if key == 'pseudo.distributed.enabled':
                     continue
+                if key in memory_configs:
+                    value += 'GB'
                 f.write(key_val_template.format(key, value))
             f.write(key_val_template.format('coordinator', 'false'))
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -20,15 +20,19 @@ import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from package.scripts.presto_coordinator import Coordinator
+from package.scripts.params import memory_configs
 from test_worker import mock_file_descriptor_write_method, \
     collect_config_vars_written_out
+
 
 class TestCoordinator(unittest.TestCase):
 
     dummy_config_properties = {'pseudo.distributed.enabled': 'true',
                                'query.queue-config-file': '',
-                               'http-server.http.port': '8081',
-                               'task.max-memory': '1GB'}
+                               'http-server.http.port': '8081'}
+
+    for memory_config in memory_configs:
+        dummy_config_properties[memory_config] = '123'
 
     def setUp(self):
         self.mock_env = MagicMock()
@@ -121,3 +125,20 @@ class TestCoordinator(unittest.TestCase):
         config = collect_config_vars_written_out(self.mock_env, Coordinator())
 
         assert 'node-scheduler.include-coordinator=true\n' in config
+
+    @patch('package.scripts.presto_coordinator.create_tpch_connector')
+    @patch('package.scripts.params.config_properties', new=dummy_config_properties)
+    def test_memory_settings_have_units(self, create_tpch_connector_mock):
+        config = collect_config_vars_written_out(self.mock_env, Coordinator())
+
+        assert_memory_configs_properly_formatted(config)
+
+
+def assert_memory_configs_properly_formatted(configs_to_test):
+    import re
+    from package.scripts.params import memory_configs
+
+    for memory_config in memory_configs:
+        result = [x for x in configs_to_test \
+                  if re.match(memory_config + '=\d*GB\n', x)]
+        assert len(result) == 1


### PR DESCRIPTION
The units cannot be included in the Ambari config defaults
because those configs have types and are parsed by Ambari.
So for example the memory configs are interpreted as integers
and if the defaults had characters, Ambari would crash.

Testing: unit tests, manual deployment