### PR TITLE
Enforce topology constraints during installation

### DIFF
--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -27,3 +27,5 @@ config_directory = '/etc/presto'
 
 memory_configs = ['query.max-memory-per-node', 'query.max-memory',
                   'task.max-memory']
+
+host_info = config['clusterHostInfo']

--- a/tests/resource_management/libraries/script/script.py
+++ b/tests/resource_management/libraries/script/script.py
@@ -8,4 +8,5 @@ class Script(object):
         return {'configurations':
                 {'node.properties': {},
                  'jvm.config': {'jvm.config': ''},
-                 'config.properties': {}}}
+                 'config.properties': {}},
+                 'clusterHostInfo': {'presto_worker_hosts': [], 'presto_coordinator_hosts': []}}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from mock import MagicMock, patch, mock_open
+from unittest import TestCase
 
 import unittest
 import os
@@ -133,6 +134,11 @@ class TestCoordinator(unittest.TestCase):
 
         assert_memory_configs_properly_formatted(config)
 
+    @patch('package.scripts.params.host_info', new={'presto_worker_hosts': ['slave1']})
+    @patch('package.scripts.presto_coordinator.create_tpch_connector')
+    @patch('package.scripts.params.config_properties', new=dummy_config_properties)
+    def test_pseudo_distributed_topology_enforced(self, create_tpch_connector_mock):
+        TestCase.assertRaises(self, RuntimeError, collect_config_vars_written_out, self.mock_env, Coordinator())
 
 def assert_memory_configs_properly_formatted(configs_to_test):
     import re


### PR DESCRIPTION
- During smoketest, check that the hosts the user specified
  at configuration are returned by Presto as workers.
- Fail the installation if the user adds worker nodes but
  specifies the cluster as pseudo-distributed. Unfortunately, this
  cannot be enforced during configuration without changing
  core Ambari and must therefore be done during smoketest.
- Unit tests for the new functionality as well as adjustments
  to existing tests.

Task: SWARM-1123, SWARM-1124