### PR TITLE
Remove the ability of a user to set the Presto data dir

### DIFF
--- a/configuration/node.properties.xml
+++ b/configuration/node.properties.xml
@@ -25,9 +25,12 @@
     </description>
   </property>
 
+<!-- User should not be allowed to set this until https://github.com/facebook/presto/issues/4063
+has been fixed. Up until then please exclude this from the theme.json enhanced configs.
+-->
   <property>
     <name>node.data-dir</name>
-    <value>/var/data/presto</value>
+    <value>/var/lib/presto</value>
     <description>
       The location (filesystem path) of the data directory. Presto will store
       logs and other data here.

--- a/themes/theme.json
+++ b/themes/theme.json
@@ -78,10 +78,6 @@
           "subsection-name": "subsection-node-config"
         },
         {
-          "config": "node.properties/node.data-dir",
-          "subsection-name": "subsection-node-config"
-        },
-        {
           "config": "node.properties/plugin.config-dir",
           "subsection-name": "subsection-node-config"
         },
@@ -128,12 +124,6 @@
         "config": "node.properties/node.environment",
         "widget": {
           "type": "text-area"
-        }
-      },
-      {
-        "config": "node.properties/node.data-dir",
-        "widget": {
-          "type": "directory"
         }
       },
       {


### PR DESCRIPTION
- The postinstall script has the Presto data directory hardcoded as
  /var/lib/presto. If the user specifies a different data directory in
  node.properties, that directory won't be created with proper permissions and
  the launcher.py script will fail with permission denied.