### PR TITLE
Require the user to set the discovery URI property

### DIFF
--- a/configuration/config.properties.xml
+++ b/configuration/config.properties.xml
@@ -114,14 +114,16 @@
     </value-attributes>
   </property>
 
-  <property>
+  <property require-input="true">
     <name>discovery.uri</name>
-    <value>http://master.net:8081</value>
+    <value></value>
     <description>
       The URI to the Discovery server. Because we have enabled the embedded
       version of Discovery in the Presto coordinator, this should be the URI of
-      the Presto coordinator. Replace http://master.net:8081 to match the host
-      and port of the Presto coordinator. This URI must not end in a slash.
+      the Presto coordinator. For example: http://master.net:8081 but make sure
+      to replace master.net with the actual hostname of your coordinator node.
+      Ensure the port in the URI matches the port set in the http-server.http.port
+      property. This URI must not end in a slash.
     </description>
   </property>
 


### PR DESCRIPTION
- Instead of having a default for the property hoping that
  the user has read the docs and changes the property, force
  the user to change the property by making it a required field
  and setting the default to nothing.