### PR TITLE
Set node.id to a UUID instead of the node's hostname

### DIFF
--- a/package/scripts/presto_client.py
+++ b/package/scripts/presto_client.py
@@ -89,7 +89,7 @@ def ensure_nodes_are_up(client, all_hosts):
         nodes_returned_from_presto = []
         for row in client.get_rows():
             nodes_returned_from_presto.append(row[0])
-        if set(nodes_returned_from_presto) == set(all_hosts):
+        if len(nodes_returned_from_presto) == len(all_hosts):
             are_expected_nodes_up = True
             break
         else:

--- a/package/scripts/presto_coordinator.py
+++ b/package/scripts/presto_coordinator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import socket
+import uuid
 import os.path as path
 
 from resource_management.libraries.script.script import Script
@@ -54,7 +54,7 @@ class Coordinator(Script):
         with open(path.join(config_directory, 'node.properties'), 'w') as f:
             for key, value in node_properties.iteritems():
                 f.write(key_val_template.format(key, value))
-            f.write(key_val_template.format('node.id', socket.gethostname()))
+            f.write(key_val_template.format('node.id', str(uuid.uuid4())))
 
         with open(path.join(config_directory, 'jvm.config'), 'w') as f:
             f.write(jvm_config['jvm.config'])

--- a/package/scripts/presto_worker.py
+++ b/package/scripts/presto_worker.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import socket
+import uuid
 import os.path as path
 
 from resource_management.libraries.script.script import Script
@@ -47,7 +47,7 @@ class Worker(Script):
         with open(path.join(config_directory, 'node.properties'), 'w') as f:
             for key, value in node_properties.iteritems():
                 f.write(key_val_template.format(key, value))
-            f.write(key_val_template.format('node.id', socket.gethostname()))
+            f.write(key_val_template.format('node.id', str(uuid.uuid4())))
 
         with open(path.join(config_directory, 'jvm.config'), 'w') as f:
             f.write(jvm_config['jvm.config'])


### PR DESCRIPTION
- Using the node's hostname as the node.id can potentially
  cause a conflict if there are multiple Presto deployments.
  An unlikely scenario but still possible. By setting node.id
  to a UUID this probability is further minimized.