### PR TITLE
Remove task.max-memory config property

### DIFF
--- a/configuration/config.properties.xml
+++ b/configuration/config.properties.xml
@@ -51,32 +51,6 @@
   </property>
 
   <property>
-    <name>task.max-memory</name>
-    <value>1GB</value>
-    <description>
-      The maximum amount of memory used by a single task (a fragment of a query
-      plan running on a specific node). In particular, this limits the number of
-      groups in a GROUP BY, the size of the right-hand table in a JOIN, the
-      number of rows in an ORDER BY or the number of rows processed by a window
-      function. This value should be tuned based on the number of concurrent
-      queries and the size and complexity of queries. Setting it too low will
-      limit the queries that can be run, while setting it too high will cause
-      the JVM to run out of memory.
-
-      If you'd like to enter a value higher
-      than the maximum on the slider, click on the pencil that appears when
-      you hover over the setting and ignore that higher values are not recommended.
-    </description>
-    <value-attributes>
-      <type>int</type>
-      <minimum>0</minimum>
-      <maximum>20</maximum>
-      <increment-step>1</increment-step>
-      <unit>GB</unit>
-    </value-attributes>
-  </property>
-
-  <property>
     <name>query.max-memory</name>
     <value>50GB</value>
     <description>

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -28,7 +28,6 @@ connectors_to_delete = config['configurations']['connectors.properties']['connec
 daemon_control_script = '/etc/init.d/presto'
 config_directory = '/etc/presto'
 
-memory_configs = ['query.max-memory-per-node', 'query.max-memory',
-                  'task.max-memory']
+memory_configs = ['query.max-memory-per-node', 'query.max-memory']
 
 host_info = config['clusterHostInfo']

--- a/themes/theme.json
+++ b/themes/theme.json
@@ -119,10 +119,6 @@
           "subsection-name": "subsection-general-config"
         },
         {
-          "config": "config.properties/task.max-memory",
-          "subsection-name": "subsection-general-config"
-        },
-        {
           "config": "config.properties/query.max-memory",
           "subsection-name": "subsection-general-config"
         },
@@ -185,17 +181,6 @@
         "config": "config.properties/http-server.http.port",
         "widget": {
           "type": "text-area"
-        }
-      },
-      {
-        "config": "config.properties/task.max-memory",
-        "widget": {
-          "type": "slider",
-          "units": [
-            {
-              "unit-name": "GB"
-            }
-          ]
         }
       },
       {


### PR DESCRIPTION
- This property was deprecated in Presto. In order to
  to make the Ambari integration work with as many Presto
  versions as possible, the code should write out the lowest
  common configuration set.