### PR TITLE
Refactor create_tpch_connector to use create_connectors

### DIFF
--- a/package/scripts/common.py
+++ b/package/scripts/common.py
@@ -27,10 +27,6 @@ PRESTO_RPM_NAME = PRESTO_RPM_URL.split('/')[-1]
 PRESTO_CLI_URL = config.get('download', 'presto_cli_url')
 PRESTO_CLI_NAME = PRESTO_CLI_URL.split('/')[-1]
 
-def create_tpch_connector(node_properties):
-    Execute('mkdir -p {0}'.format(node_properties['plugin.config-dir']))
-    Execute('echo "connector.name=tpch" > {0}'.format(os.path.join(node_properties['plugin.config-dir'], 'tpch.properties')))
-
 def create_connectors(node_properties, connectors_to_add):
     if not connectors_to_add:
         return

--- a/package/scripts/presto_coordinator.py
+++ b/package/scripts/presto_coordinator.py
@@ -17,7 +17,7 @@ import os.path as path
 
 from resource_management.libraries.script.script import Script
 from resource_management.core.resources.system import Execute
-from common import create_tpch_connector, PRESTO_RPM_URL, PRESTO_RPM_NAME, create_connectors,\
+from common import PRESTO_RPM_URL, PRESTO_RPM_NAME, create_connectors,\
     delete_connectors
 from presto_client import smoketest_presto, PrestoClient
 
@@ -83,7 +83,9 @@ class Coordinator(Script):
 
         create_connectors(node_properties, connectors_to_add)
         delete_connectors(node_properties, connectors_to_delete)
-        create_tpch_connector(node_properties)
+        # This is a separate call because we always want the tpch connector to
+        # be available because it is used to smoketest the installation.
+        create_connectors(node_properties, "{'tpch': ['connector.name=tpch']}")
 
 
 if __name__ == '__main__':

--- a/package/scripts/presto_worker.py
+++ b/package/scripts/presto_worker.py
@@ -17,7 +17,7 @@ import os.path as path
 
 from resource_management.libraries.script.script import Script
 from resource_management.core.resources.system import Execute
-from common import create_tpch_connector, PRESTO_RPM_URL, PRESTO_RPM_NAME, create_connectors, \
+from common import PRESTO_RPM_URL, PRESTO_RPM_NAME, create_connectors, \
     delete_connectors
 
 
@@ -67,7 +67,9 @@ class Worker(Script):
 
         create_connectors(node_properties, connectors_to_add)
         delete_connectors(node_properties, connectors_to_delete)
-        create_tpch_connector(node_properties)
+        # This is a separate call because we always want the tpch connector to
+        # be available because it is used to smoketest the installation.
+        create_connectors(node_properties, "{'tpch': ['connector.name=tpch']}")
 
 if __name__ == '__main__':
     Worker().execute()


### PR DESCRIPTION
- This refactor ensure that all methods that create connectors
  go through the same code path.