### PR TITLE
Update RPM and CLI links to 0.161

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -48,7 +48,7 @@ simple. Execute ``make dist`` to build the distribution, ``make test`` to run
 the unit tests and ``make help`` to get more info on all the available
 targets.
 
-By default, the integration code installs Presto version ``0.148``. Change the
+By default, the integration code installs Presto version ``0.161``. Change the
 version displayed by Ambari when adding the Presto service by specifying a
 value for the ``VERSION`` variable when building the distribution. For
 example, to display Presto version ``0.134``, run ``make dist VERSION=0.134``.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -23,7 +23,7 @@ Adding the Presto service
 
 This section and all others that follow within :ref:`Getting Started <getting_started>`
 walk you through the integration steps needed to get Presto working with
-Ambari. By default, this integration code installs Presto version ``0.148``,
+Ambari. By default, this integration code installs Presto version ``0.161``,
 the latest version at the time of writing. To install the latest Teradata
 Presto release (``0.148t`` at the time of writing), download the Ambari
 integration package from `here <http://www.teradata.com/presto>`_ and follow
@@ -32,13 +32,13 @@ another version, see :ref:`Build and custom distributions <build_and_custom_dist
 
 To integrate the Presto service with Ambari, follow the steps outlined below:
 
-* Assuming HDP 2.3 was installed with Ambari, create the following directory on
+* Assuming HDP 2.5 was installed with Ambari, create the following directory on
   the node where the ``ambari-server`` is running:
 
   .. code-block:: bash
 
-    $ mkdir /var/lib/ambari-server/resources/stacks/HDP/2.3/services/PRESTO
-    $ cd /var/lib/ambari-server/resources/stacks/HDP/2.3/services/PRESTO
+    $ mkdir /var/lib/ambari-server/resources/stacks/HDP/2.5/services/PRESTO
+    $ cd /var/lib/ambari-server/resources/stacks/HDP/2.5/services/PRESTO
 
 * Place the integration files within the newly created PRESTO directory.
   Download the integration package that installs Teradata's version from
@@ -47,15 +47,15 @@ To integrate the Presto service with Ambari, follow the steps outlined below:
 
   .. code-block:: bash
 
-    $ tar -xvf /path/to/integration/package/ambari-presto-1.1.tar.gz -C /var/lib/ambari-server/resources/stacks/HDP/2.3/services/PRESTO
-    $ mv /var/lib/ambari-server/resources/stacks/HDP/2.3/services/PRESTO/ambari-presto-1.1/* /var/lib/ambari-server/resources/stacks/HDP/2.3/services/PRESTO
-    $ rm -rf /var/lib/ambari-server/resources/stacks/HDP/2.3/services/PRESTO/ambari-presto-1.1
+    $ tar -xvf /path/to/integration/package/ambari-presto-1.2.tar.gz -C /var/lib/ambari-server/resources/stacks/HDP/2.5/services/PRESTO
+    $ mv /var/lib/ambari-server/resources/stacks/HDP/2.5/services/PRESTO/ambari-presto-1.2/* /var/lib/ambari-server/resources/stacks/HDP/2.5/services/PRESTO
+    $ rm -rf /var/lib/ambari-server/resources/stacks/HDP/2.5/services/PRESTO/ambari-presto-1.2
 
 * Finally, make all integration files executable and restart the Ambari server:
 
   .. code-block:: bash
 
-    $ chmod -R +x /var/lib/ambari-server/resources/stacks/HDP/2.3/services/PRESTO/*
+    $ chmod -R +x /var/lib/ambari-server/resources/stacks/HDP/2.5/services/PRESTO/*
     $ ambari-server restart
 
 * Once the server has restarted, point your browser to it and on the main

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -24,7 +24,7 @@
         interactive analytic queries against data sources of all sizes ranging
         from gigabytes to petabytes.
       </comment>
-      <version>0.148</version>
+      <version>0.161</version>
       <components>
         <component>
           <name>PRESTO_COORDINATOR</name>

--- a/package/scripts/download.ini
+++ b/package/scripts/download.ini
@@ -1,3 +1,3 @@
 [download]
-presto_rpm_url = http://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server-rpm/0.148/presto-server-rpm-0.148.rpm
-presto_cli_url = http://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.148/presto-cli-0.148-executable.jar
+presto_rpm_url = http://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server-rpm/0.161/presto-server-rpm-0.161.rpm
+presto_cli_url = http://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.161/presto-cli-0.161-executable.jar

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ test_requirements = [
 
 setup(
     name='ambari-presto',
-    version='1.1',
+    version='1.2',
     description='This project contains the integration code for integrating \
 Presto as a service in Ambari.',
     long_description=readme + '\n\n' + history,


### PR DESCRIPTION
Presto 0.161 works well on my HDP 2.5 cluster.

It would be good to update the main repo to the new version.