### PR TITLE
using set() to deduplicate hosts in all_hosts

### DIFF
--- a/package/scripts/presto_coordinator.py
+++ b/package/scripts/presto_coordinator.py
@@ -40,8 +40,8 @@ class Coordinator(Script):
         self.configure(env)
         Execute('{0} start'.format(daemon_control_script))
         if 'presto_worker_hosts' in host_info.keys():
-            all_hosts = host_info['presto_worker_hosts'] + \
-                        host_info['presto_coordinator_hosts']
+            all_hosts = set(host_info['presto_worker_hosts'] + \
+                        host_info['presto_coordinator_hosts'])
         else:
             all_hosts = host_info['presto_coordinator_hosts']
         smoketest_presto(PrestoClient('localhost', 'root', config_properties['http-server.http.port']), all_hosts)


### PR DESCRIPTION
originally, all_hosts is a list containing presto_worker_hosts and presto_coordinator_hosts, which may be overlapped. we can convert it to set to pass the check in presto_client.py.